### PR TITLE
Make sure that topic slugs don't exist twice

### DIFF
--- a/Controller/TopicController.php
+++ b/Controller/TopicController.php
@@ -48,6 +48,15 @@ class TopicController extends Controller
         $this->get('herzult_forum.blamer.post')->blame($topic->getFirstPost());
 
         $objectManager = $this->get('herzult_forum.object_manager');
+
+        $newSlug = $topic->getSlug();
+        do {
+            $slugExists = $this->get('herzult_forum.repository.topic')->findOneByCategoryAndSlug($category, $newSlug.(isset($appendix) ? '-'.$appendix : ''));
+            $appendix = isset($appendix) ? $appendix+1 : 1;
+        } while (!is_null($slugExists));
+        $newSlug = $appendix > 1 ? $newSlug.'-'.($appendix-1) : $newSlug;
+        $topic->setSlug($newSlug);
+
         $objectManager->persist($topic);
         $objectManager->persist($topic->getFirstPost());
         $objectManager->flush();


### PR DESCRIPTION
I know that this repository is quite old, but I thought, maybe there is someone (re)using it.

Anyway, this pull request checks whether a topic slug already exists and if so, it adds a number to the new slug. Otherwise, links might lead to the wrong topic.